### PR TITLE
Modify Transformation interface

### DIFF
--- a/test_twosheds.py
+++ b/test_twosheds.py
@@ -1,18 +1,58 @@
-from twosheds.transformation import TildeTransformation
+from twosheds.transformation import (AliasTransformation,
+                                     VariableTransformation,
+                                     TildeTransformation,)
+
+
+def test_alias_substitution1():
+    """Alias substitution should expand aliases."""
+    aliases = {"ls": "ls -G"}
+    transformation = AliasTransformation(aliases)
+    text = "ls"
+    assert transformation.decode(text) == "ls -G"
+
+
+def test_alias_substitution2():
+    """Alias substitution should not expand arguments."""
+    aliases = {"ls": "ls -G"}
+    transformation = AliasTransformation(aliases)
+    text = "echo ls"
+    assert transformation.decode(text) == "echo ls"
+
+
+def test_alias_substitution_inverse():
+    """Alias substitution should have an inverse."""
+    aliases = {"ls": "ls -G"}
+    transformation = AliasTransformation(aliases)
+    text = "ls"
+    assert transformation.encode(transformation.decode(text)) == text
+
+
+def test_variable_substitution_inverse():
+    environment = {"$HOME": "/user/twosheds"}
+    transformation = VariableTransformation(environment)
+    text = "$"
+    assert transformation.encode(transformation.decode(text)) == text
 
 
 def test_tilde_substitution1():
-    """Ensure tilde substitution substitutes $HOME."""
+    """Tilde substitution should expand ``~`` as ``$HOME``."""
     transformation = TildeTransformation()
     text = "cd ~/Desktop"
-    assert transformation.expand(text) == "cd $HOME/Desktop"
+    assert transformation.decode(text) == "cd $HOME/Desktop"
 
 
 def test_tilde_substitution2():
     """
-    Ensure tilde substitution does not substitutes unless ``~`` is at start of
-    token.
+    Tilde substitution should not expand a tilde unless it is the prefix
+    of a token.
     """
     transformation = TildeTransformation()
     text = "git rebase -i HEAD~3"
-    assert transformation.expand(text) == text
+    assert transformation.decode(text) == text
+
+
+def test_tilde_substitution_inverse():
+    """Tilde substitution should have an inverse."""
+    transformation = TildeTransformation()
+    text = "cd ~/Desktop"
+    assert transformation.encode(transformation.decode(text)) == text

--- a/twosheds/grammar.py
+++ b/twosheds/grammar.py
@@ -18,7 +18,7 @@ class Grammar(object):
     def expand(self, sentence):
         """Rewrite a sentence to make it suitable for evaluation."""
         for transformation in self.transformations:
-            sentence = transformation.expand(sentence)
+            sentence = transformation.decode(sentence)
         return sentence
 
     def parse(self, source_text):

--- a/twosheds/transformation.py
+++ b/twosheds/transformation.py
@@ -11,44 +11,80 @@ string with a new derived constituent structure.
 """
 import os
 
+
 class Transformation(object):
-    def expand(self, sentece):
-        raise NotImplementedError("Transformations must implement ``expand``.")
+    def encode(self, sentence):
+        """Transform a sentence toward a surface sentence."""
+        raise NotImplementedError("Transformations must implement ``decode``.")
+
+    def decode(self, sentence):
+        """Transform a sentence toward a kernel sentence."""
+        raise NotImplementedError("Transformations must implement ``decode``.")
 
 
 class AliasTransformation(Transformation):
-    """Expands user-defined aliases."""
+    """
+    Expands user-defined aliases.
+
+    A token is a candidate for alias expansion only if it it the first
+    token in a sentence.
+
+    :param aliases: dictionary of aliases to expand
+    """
     def __init__(self, aliases):
         self.aliases = aliases or {}
 
-    def expand(self, sentence):
-        """Expand aliases in a sentence.
-        
-        A token is a candidate for alias expansion only if it it the first
-        token in a sentence.
-        """
+    def encode(self, sentence):
+        for k, v in self.aliases.iteritems():
+            if sentence.startswith(v):
+                sentence = sentence.replace(v, k)
+                break
+        return sentence
+
+    def decode(self, sentence):
         try:
             command, args = sentence.split(" ", 1)
         except ValueError:
             command, args = sentence, ""
         try:
-            return "%s %s" % (self.aliases[command], args)
+            if args:
+                return "%s %s" % (self.aliases[command], args)
+            else:
+                return "%s" % (self.aliases[command],)
         except KeyError:
             return sentence
 
 
 class VariableTransformation(Transformation):
-    """Expands environmental variables."""
-    def expand(self, sentence):
+    """Expands environmental variables.
+    
+    :param environment: dictionary of variables to expand
+    """
+    def __init__(self, environment=None):
+        self.environment = environment or {}
+
+    def encode(self, sentence):
+        for k, v in self.environment.iteritems():
+            if v in sentence:
+                return sentence.replace(v, "$" + k)
+        return sentence
+
+    def decode(self, sentence):
         """Expand environmental variables in a sentence."""
-        for k, v in os.environ.iteritems():
+        for k, v in self.environment.iteritems():
             sentence = sentence.replace("$" + k, v)
         return sentence
 
 
 class TildeTransformation(Transformation):
     """Expands ``~`` to ``$HOME``"""
-    def expand(self, sentence):
+
+    def encode(self, sentence):
         tokens = sentence.split()
-        return " ".join(token.replace("~", "$HOME") if token.startswith("~")
-                        else token for token in tokens)
+        return " ".join((token.replace("$HOME", "~") if token.startswith("$HOME")
+                        else token) for token in tokens)
+
+    def decode(self, sentence):
+        tokens = sentence.split()
+        return " ".join((token.replace("~", "$HOME") if token.startswith("~")
+                         else token) for token in tokens)


### PR DESCRIPTION
This changes the Transformation interface from simply requiring
`expand` to requiring `encode` and `decode`, where the latter are
inverses and `decode` performs the same role as `expand`.
